### PR TITLE
Prevent modification of Deployment objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/tomdyson/wagtail-netlify/compare/v0.1...HEAD)
 
+### Fixed
+
+- Prevent modification of Deployment objects #2
+
 ## [v0.1](https://github.com/tomdyson/wagtail-netlify/compare/f8f45701f43e28e238fc64aceea07dd1900343fc...v0.1)
 
 Initial Release

--- a/wagtailnetlify/wagtail_hooks.py
+++ b/wagtailnetlify/wagtail_hooks.py
@@ -1,30 +1,26 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.contrib.modeladmin.helpers import ButtonHelper, PermissionHelper
+from wagtail.contrib.modeladmin.helpers import PermissionHelper
 from wagtailnetlify.models import Deployment
 
 
-class NoAddPermissionHelper(PermissionHelper):
+class DeploymentPermissionHelper(PermissionHelper):
     # remove the add Deployment button
     def user_can_create(self, user):
         return False
 
-class NoEditButtonHelper(ButtonHelper):
-    # remove the edit button from the listing
-    def get_buttons_for_obj(self, obj, exclude=[], classnames_add=[],
-                            classnames_exclude=[]):
-        btns = super(NoEditButtonHelper, self).get_buttons_for_obj(obj)
-        return [btn for btn in btns if btn['label'] != u'Edit']
+    def user_can_edit_obj(self, user, obj):
+        return False
+
 
 class DeploymentAdmin(ModelAdmin):
     model = Deployment
-    menu_icon = 'success'  
-    menu_order = 0 
+    menu_icon = 'success'
+    menu_order = 0
     add_to_settings_menu = True
     exclude_from_explorer = False
     list_display = ('datetime_started', 'datetime_finished', 'deployment_url', 'url')
     list_filter = ('datetime_started',)
     inspect_view_enabled=True
-    button_helper_class = NoEditButtonHelper
-    permission_helper_class = NoAddPermissionHelper
+    permission_helper_class = DeploymentPermissionHelper
 
 modeladmin_register(DeploymentAdmin)


### PR DESCRIPTION
The previous implementation was simply hiding the edit button and the model could be modified by directly visiting `/admin/wagtailnetlify/deployment/edit/xxx/` (where xxx is the object ID).