### PR TITLE
Add Wagtail 2.0 Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/tomdyson/wagtail-netlify/compare/v0.1...HEAD)
 
+### Added
+
+- Wagtail 2.0 compatibility
+
 ### Fixed
 
 - Prevent modification of Deployment objects #2

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "wagtail>=1.6",
-        "wagtail-bakery>=0.1.0"
+        "wagtail-bakery>=0.3.0"
     ],
 )

--- a/wagtailnetlify/management/commands/netlify.py
+++ b/wagtailnetlify/management/commands/netlify.py
@@ -2,8 +2,12 @@ import os
 import subprocess
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
-from wagtail.wagtailredirects.models import Redirect
 from wagtailnetlify.models import Deployment
+
+try:
+    from wagtail.contrib.redirects.models import Redirect
+except ImportError:  # Wagtail < 2.0
+    from wagtail.wagtailredirects.models import Redirect
 
 
 class Command(BaseCommand):

--- a/wagtailnetlify/models.py
+++ b/wagtailnetlify/models.py
@@ -3,7 +3,11 @@ from django.db import models
 from django.core.management import call_command
 from django.db import connection
 from django.conf import settings
-from wagtail.wagtailcore.signals import page_published
+
+try:
+    from wagtail.wagtailcore.signals import page_published
+except ImportError:  # Wagtail < 2.0
+    from wagtail.core.signals import page_published
 
 
 class Deployment(models.Model):


### PR DESCRIPTION
~**Do not merge this PR yet!** See `setup.py` comment below.~

We discussed earlier that you would need to publish the package to Pypi before making a Wagtail 2.0 compatible version, and then publish another version which is Wagtail 2.0 only. However, since the changes are small, it's possible keep supporting older version (which is also a good thing since [`wagtail-bakery` still supports `Wagtail>=1.6`](https://github.com/moorinteractive/wagtail-bakery/blob/057bce7de29277ba4469d3a26a349df63523ab7a/setup.py#L7)).

Note that with Wagtail 2.0, comes the support for Django 2.0 as well. This PR does not update `urls.py` since Django 2.0 still supports (and does not deprecate yet) the old way.