### PR TITLE
Replace Netlify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Deploy your Wagtail site on Netlify. Features include:
 ## Install
 
 1. Install and configure [Wagtail Bakery](https://github.com/moorinteractive/wagtail-bakery), if you haven't already
-2. Install [Netlify](https://www.netlify.com/docs/cli/#installation), if you haven't already
+2. Install [Netlify](https://github.com/netlify/netlifyctl), if you haven't already
 3. `pip install git+https://github.com/tomdyson/wagtail-netlify.git`
 
 ## Configure

--- a/wagtailnetlify/management/commands/netlify.py
+++ b/wagtailnetlify/management/commands/netlify.py
@@ -37,12 +37,12 @@ class Command(BaseCommand):
         deployment.save()
 
         netlify_cli = settings.NETLIFY_PATH
-        command = [netlify_cli, 'deploy', '-P', settings.BUILD_DIR]
+        command = [netlify_cli, 'deploy', '--publish-directory', settings.BUILD_DIR]
         if hasattr(settings, 'NETLIFY_SITE_ID'):
-            command.extend(['-s', settings.NETLIFY_SITE_ID])
+            command.extend(['--site-id', settings.NETLIFY_SITE_ID])
         token = getattr(settings, 'NETLIFY_API_TOKEN', None)
         if token:
-            command.extend(['-A', token])
+            command.extend(['--access-token', token])
         subprocess.call(command)
 
     def handle(self, *args, **options):

--- a/wagtailnetlify/management/commands/netlify.py
+++ b/wagtailnetlify/management/commands/netlify.py
@@ -37,12 +37,12 @@ class Command(BaseCommand):
         deployment.save()
 
         netlify_cli = settings.NETLIFY_PATH
-        command = [netlify_cli, 'deploy', '-p', settings.BUILD_DIR]
+        command = [netlify_cli, 'deploy', '-P', settings.BUILD_DIR]
         if hasattr(settings, 'NETLIFY_SITE_ID'):
             command.extend(['-s', settings.NETLIFY_SITE_ID])
         token = getattr(settings, 'NETLIFY_API_TOKEN', None)
         if token:
-            command.extend(['-t', token])
+            command.extend(['-A', token])
         subprocess.call(command)
 
     def handle(self, *args, **options):

--- a/wagtailnetlify/models.py
+++ b/wagtailnetlify/models.py
@@ -26,7 +26,7 @@ def postpone(function):
 def deploy(sender, **kwargs):
     """ build static pages, then send incremental changes to netlify """
     call_command('build')
-    call_command('netlify')
+    call_command('netlify', '--no-confirmation')
     connection.close()
 
 if hasattr(settings, 'NETLIFY_AUTO_DEPLOY') and settings.NETLIFY_AUTO_DEPLOY == False:


### PR DESCRIPTION
Edit: **DO NOT MERGE** as they apparently [de-deprecated the old tool](https://github.com/netlify/cli/pull/51/files#diff-04c6e90faac2675aa89e2176d2eec7d8L5)... I'll investigate.

Netlify is deprecating their Node based CLI (see the first paragraph on both the [documentation](https://www.netlify.com/docs/cli/) and the [repo](https://github.com/netlify/netlify-cli)) in favour of a Go based one called [Netlify CTL](https://github.com/netlify/netlifyctl).

This PR updates the code and the documentation to use the new CLI.

In addition, the `netlify` command now accepts a `--no-confirmation` option to prevent the underlying CLI to show any prompt. This option is used when deploying from the `page_publish` signal (because nobody can act on the prompt in this case) but is otherwise not used by default.

**Note that it is a breaking change** so we should release the package on `pypi` as `v0.1` before merging this (so users can update their requirements from `git+git://github.com/tomdyson/wagtail-netlify.git` to `wagtailnetlify==0.1` if they are not ready for the change) and then we can merge this and release `v0.2`. I'm happy to help with the process.